### PR TITLE
Make Ubuntu the default distribution for /etc/lsb-release

### DIFF
--- a/os.json
+++ b/os.json
@@ -1,7 +1,7 @@
 {
   "/etc/redhat-release" : ["RHEL","RHAS","Red Hat Linux","Scientific Linux","ScientificSL","ScientificCERNSLC","ScientificFermiLTS","ScientificSLF","Centos"],
   "/etc/redhat_version" : ["RHEL","RHAS","Red Hat Linux","Scientific Linux","ScientificSL","ScientificCERNSLC","ScientificFermiLTS","ScientificSLF"],
-  "/etc/lsb-release" : ["Chakra","IYCC","Linux Mint","Ubuntu Linux"],
+  "/etc/lsb-release" : ["Ubuntu Linux","Chakra","IYCC","Linux Mint"],
   "/etc/debian_version" : ["Debian"],
   "/etc/debian_release" : ["Debian"],
   "/etc/annvix-release" : ["Annvix"],


### PR DESCRIPTION
Ubuntu is way more popular than Chakra, so it is reasonable to make it the default.

The distribution that comes first in the list is the default. If no distributions are detected for a given release file, the first one is returned (instead of the error being raised). This is probably due to large amount of derived distributions, compatible with the one they were derived from.