### PR TITLE
Don't update cache and call back twice

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@ var async = require('async')
 var distros = require('./os.json')
 var fs = require('fs')
 var os = require('os')
-var once = require('once')
 
 /**
  * Begin definition of globals.
@@ -28,8 +27,6 @@ module.exports = function getOs(cb) {
  * Identify the actual distribution name on a linux box.
  */
 function getLinuxDistro(cb) {
-  cb = once(cb) // only allow cb to be called once.
-
   /**
    * First, we check to see if this function has been called before.
    * Since an OS doesn't change during runtime, its safe to cache
@@ -84,9 +81,8 @@ function getLinuxDistro(cb) {
         check = candidate.split(" ")[0].toLowerCase()
         if(file.indexOf(check)>=0) {
           os.dist = candidate
-          return customLogic(os,file,function(e,os) {
-            cachedDistro = os
-            cb(null,os)
+          return customLogic(os,file,function(e, augmentedOs) {
+            os = augmentedOs;
             return done();
           })
         } else {

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
     "sleep": "^1.1.8"
   },
   "dependencies": {
-    "async": "^0.9.0",
-    "once": "^1.3.0"
+    "async": "^0.9.0"
   },
   "contributors": [
     {


### PR DESCRIPTION
These lines are executed both inside async map and at the end of it:

```js
cachedDistro = os
cb(null,os)
```

This patch removes those that are inside. As a bonus, `once` is no longer required, as the callback won't be called more than once naturally.