### PR TITLE
fix(deps): update dependency async to version 3.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "tape": "^5.0.1"
   },
   "dependencies": {
-    "async": "^3.2.0"
+    "async": "^3.2.4"
   },
   "contributors": [
     {


### PR DESCRIPTION
In Async before 2.6.4 and 3.x before 3.2.2, a malicious user can obtain privileges via the mapValues() method, aka lib/internal/iterator.js

@see https://nvd.nist.gov/vuln/search/results?form_type=Advanced&results_type=overview&search_type=all&cpe_vendor=cpe%3A%2F%3Aasync_project&cpe_product=cpe%3A%2F%3Aasync_project%3Aasync&cpe_version=cpe%3A%2F%3Aasync_project%3Aasync%3A3.2.0